### PR TITLE
fix: update macOS platform in CI workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,10 @@ jobs:
             cache_key: macos-arm64
             args: "--target aarch64-apple-darwin --bundles dmg -- --features stems"
 
-          - platform: macos-13
+          # macos-13 retired Dec 2025 — GitHub never rejects the label, job
+          # queues forever. macos-15-intel is the last hosted x86_64 image
+          # (gone Fall 2027). See actions/runner-images#13046.
+          - platform: macos-15-intel
             rust_targets: x86_64-apple-darwin
             cache_key: macos-x64
             args: "--target x86_64-apple-darwin --bundles dmg -- --features stems"


### PR DESCRIPTION
Replaced the retired macOS-13 platform with macOS-15-intel in the GitHub Actions workflow for building and packaging, ensuring compatibility with the latest hosted images. Added comments to clarify the retirement status of macOS-13 and the implications for future builds.